### PR TITLE
Service関係クラスの追加

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2671636A252B1B460088E48F /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26716369252B1B460088E48F /* Service.swift */; };
 		2680B55F25288AB500DEC550 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2680B55E25288AB500DEC550 /* Repository.swift */; };
 		BF0A658D244F2A3B00280FA6 /* ViewController2.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* ViewController2.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		26716369252B1B460088E48F /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		2680B55E25288AB500DEC550 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* ViewController2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController2.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -106,6 +108,7 @@
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				BFD945E2244DC5E80012785A /* ViewController.swift */,
+				26716369252B1B460088E48F /* Service.swift */,
 				BF0A658C244F2A3B00280FA6 /* ViewController2.swift */,
 				2680B55E25288AB500DEC550 /* Repository.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
@@ -270,6 +273,7 @@
 				2680B55F25288AB500DEC550 /* Repository.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
+				2671636A252B1B460088E48F /* Service.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck/Service.swift
+++ b/iOSEngineerCodeCheck/Service.swift
@@ -1,0 +1,60 @@
+//
+//  Service.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Yoshiki Tsukada on 2020/10/05.
+//  Copyright © 2020 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol APIServiceProtocol {
+    func request<Output: Decodable>(urlString: String, onSuccess completionHandler: ((Output) -> Void)?, onError errorHandler: ((Error) -> Void)?)
+}
+
+final class APIClient: APIServiceProtocol {
+    private var task: URLSessionTask?
+
+    func request<Output: Decodable>(urlString: String, onSuccess completionHandler: ((Output) -> Void)?, onError errorHandler: ((Error) -> Void)?) {
+        guard let url = URL(string: urlString) else {
+            assertionFailure()
+            return
+        }
+
+        task = URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error = error {
+                errorHandler?(error)
+                return
+            }
+
+            guard let data = data else { return }
+            do {
+                let output = try JSONDecoder().decode(Output.self, from: data)
+                DispatchQueue.main.async {
+                    completionHandler?(output)
+                }
+            } catch {
+                errorHandler?(error)
+            }
+        }
+        task?.resume()
+    }
+
+    func cancel() {
+        task?.cancel()
+    }
+}
+
+final class GitHubAPIService {
+    private var service: APIClient?
+
+    func request(by term: String, onSuccess completionHandler: ((SearchResult) -> Void)? = nil, onError errorHandler: ((Error) -> Void)? = nil) {
+        let urlString = "https://api.github.com/search/repositories?q=\(term)"
+        service = APIClient()
+        service?.request(urlString: urlString, onSuccess: completionHandler, onError: errorHandler)
+    }
+
+    func cancel() {
+        service?.cancel()
+    }
+}


### PR DESCRIPTION
`ViewController`にAPIService関係のコードが記述されていたので`GitHubAPIService`, `APIClient`クラスに責務を分割しました。
issueで言うと`Fat VC の回避 #5`, `プログラム構造をリファクタリング #6`に対応します。