### PR TITLE
index変数の削除

### DIFF
--- a/iOSEngineerCodeCheck/ViewController.swift
+++ b/iOSEngineerCodeCheck/ViewController.swift
@@ -11,9 +11,8 @@ import UIKit
 final class ViewController: UITableViewController, UISearchBarDelegate {
     @IBOutlet private var searchBar: UISearchBar!
 
-    private(set) var searchResult: SearchResult?
+    private var searchResult: SearchResult?
     private var task: GitHubAPIService?
-    private(set) var index: Int?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,7 +43,7 @@ final class ViewController: UITableViewController, UISearchBarDelegate {
                 assertionFailure()
                 return
             }
-            vc.vc = self
+            vc.repository = sender as? Repository
         }
     }
 
@@ -54,16 +53,15 @@ final class ViewController: UITableViewController, UISearchBarDelegate {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell()
-        let rp = searchResult?.repositories[indexPath.row]
-        cell.textLabel?.text = rp?.name
-        cell.detailTextLabel?.text = rp?.language
+        let repo = searchResult?.repositories[indexPath.row]
+        cell.textLabel?.text = repo?.name
+        cell.detailTextLabel?.text = repo?.language
         cell.tag = indexPath.row
         return cell
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // 画面遷移時に呼ばれる
-        index = indexPath.row
-        performSegue(withIdentifier: "Detail", sender: self)
+        let repo = searchResult?.repositories[indexPath.row]
+        performSegue(withIdentifier: "Detail", sender: repo)
     }
 }

--- a/iOSEngineerCodeCheck/ViewController2.swift
+++ b/iOSEngineerCodeCheck/ViewController2.swift
@@ -17,13 +17,17 @@ final class ViewController2: UIViewController {
     @IBOutlet private var forksLabel: UILabel!
     @IBOutlet private var issuesLabel: UILabel!
 
-    var vc: ViewController?
+    var repository: Repository?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupViews()
+    }
 
-        guard let index = vc?.index, let repo = vc?.searchResult?.repositories[index] else { return }
+    private func setupViews() {
+        guard let repo = repository else { return }
 
+        titleLabel.text = repo.name
         languageLabel.text = "Written in \(repo.language ?? "")"
         starsLabel.text = "\(repo.starsCount) stars"
         watchersLabel.text = "\(repo.watchersCount) watchers"
@@ -33,10 +37,7 @@ final class ViewController2: UIViewController {
     }
 
     private func getImage() {
-        guard let index = vc?.index, let repo = vc?.searchResult?.repositories[index] else { return }
-
-        titleLabel.text = repo.name
-
+        guard let repo = repository else { return }
         guard let url = URL(string: repo.avatarUrl) else { return }
 
         URLSession.shared.dataTask(with: url) { data, _, err in


### PR DESCRIPTION
`ViewController` 内にあった`index`変数を削除し、代わりに`ViewController2`にリポジトリを保持させるようにしました。